### PR TITLE
Accept lowercase vCards

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -58,7 +58,7 @@ pub trait Component {
                 };
             }
 
-            match line.name.as_str() {
+            match line.name.to_uppercase().as_str() {
                 "END" => break,
                 "BEGIN" => match line.value {
                     Some(v) => self.add_sub_component(v.as_str(), line_parser)?,

--- a/src/parser/vcard/mod.rs
+++ b/src/parser/vcard/mod.rs
@@ -66,9 +66,9 @@ impl<B: BufRead> VcardParser<B> {
             None => return Ok(None),
         };
 
-        if line.name != "BEGIN"
+        if line.name.to_uppercase() != "BEGIN"
             || line.value.is_none()
-            || line.value.unwrap() != "VCARD"
+            || line.value.unwrap().to_uppercase() != "VCARD"
             || line.params != None
         {
             return Err(ParserError::MissingHeader.into());

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -160,4 +160,25 @@ pub mod parser {
             assert_eq!(output, valids.next().unwrap().unwrap());
         }
     }
+
+    #[test]
+    fn vcard_lowercase() {
+        let input = BufReader::new(File::open("./tests/ressources/vcard_lowercase.vcf").unwrap());
+
+        let mut valids =
+            BufReader::new(File::open("./tests/ressources/vcard_lowercase.res").unwrap()).lines();
+
+        let reader = ical::VcardParser::new(input);
+
+        for res in reader {
+            let contact = match res {
+                Ok(res) => res,
+                Err(err) => panic!("Throw error: {:?}", err),
+            };
+
+            let output = format!("{:?}", contact);
+
+            assert_eq!(output, valids.next().unwrap().unwrap());
+        }
+    }
 }

--- a/tests/ressources/vcard_lowercase.res
+++ b/tests/ressources/vcard_lowercase.res
@@ -1,0 +1,1 @@
+VcardContact { properties: [Property { name: "version", params: None, value: Some("4.0") }, Property { name: "fn", params: None, value: Some("Alice Foobar") }, Property { name: "n", params: None, value: Some("Foobar;Alice") }, Property { name: "email", params: Some([("TYPE", ["internet"])]), value: Some("alice@example.org") }] }

--- a/tests/ressources/vcard_lowercase.vcf
+++ b/tests/ressources/vcard_lowercase.vcf
@@ -1,0 +1,6 @@
+begin:vcard
+version:4.0
+fn:Alice Foobar
+n:Foobar;Alice
+email;type=internet:alice@example.org
+end:vcard


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc6350 property names and
values of BEGIN and END are case-insensitive.

Also Thunderbird sends lowercase vCard when asked to attach one, although
it can't be parsed anyway because it uses version 2.1 format for output.