### PR TITLE
Ical serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ repository = "https://travis-ci.org/Peltoche/ical-rs"
 
 [dependencies]
 thiserror = "1.0.20"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 
 [features]
@@ -29,6 +30,7 @@ ical = ["property"]
 line = []
 property = ["line"]
 vcard = ["property"]
+serde-derive = ["serde"]
 
 [lib]
 doc = true

--- a/src/parser/ical/component.rs
+++ b/src/parser/ical/component.rs
@@ -2,12 +2,16 @@
 use std::cell::RefCell;
 use std::io::BufRead;
 
+#[cfg(feature = "serde-derive")]
+extern crate serde;
+
 // Internal mods
 use crate::parser::Component;
 use crate::parser::ParserError;
 use crate::property::{Property, PropertyParser};
 
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// An ICAL calendar.
 pub struct IcalCalendar {
     pub properties: Vec<Property>,
@@ -82,6 +86,7 @@ impl Component for IcalCalendar {
 }
 
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct IcalAlarm {
     pub properties: Vec<Property>,
 }
@@ -109,6 +114,7 @@ impl Component for IcalAlarm {
 }
 
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct IcalEvent {
     pub properties: Vec<Property>,
     pub alarms: Vec<IcalAlarm>,
@@ -147,6 +153,7 @@ impl Component for IcalEvent {
 }
 
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct IcalJournal {
     pub properties: Vec<Property>,
 }
@@ -174,6 +181,7 @@ impl Component for IcalJournal {
 }
 
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct IcalTodo {
     pub properties: Vec<Property>,
     pub alarms: Vec<IcalAlarm>,
@@ -212,6 +220,7 @@ impl Component for IcalTodo {
 }
 
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct IcalTimeZone {
     pub properties: Vec<Property>,
     pub transitions: Vec<IcalTimeZoneTransition>,
@@ -250,6 +259,7 @@ impl Component for IcalTimeZone {
 }
 
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct IcalTimeZoneTransition {
     pub properties: Vec<Property>,
 }
@@ -277,6 +287,7 @@ impl Component for IcalTimeZoneTransition {
 }
 
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct IcalFreeBusy {
     pub properties: Vec<Property>,
 }

--- a/src/parser/vcard/component.rs
+++ b/src/parser/vcard/component.rs
@@ -2,11 +2,15 @@
 use std::cell::RefCell;
 use std::io::BufRead;
 
+#[cfg(feature = "serde-derive")]
+extern crate serde;
+
 // Internal mods
 use crate::parser::{Component, ParserError};
 use crate::property::{Property, PropertyParser};
 
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A VCARD contact.
 pub struct VcardContact {
     pub properties: Vec<Property>,

--- a/src/property.rs
+++ b/src/property.rs
@@ -42,6 +42,9 @@ use std::fmt;
 use std::io::BufRead;
 use std::iter::Iterator;
 
+#[cfg(feature = "serde-derive")]
+extern crate serde;
+
 // Internal mods
 use crate::line::{Line, LineReader};
 
@@ -61,6 +64,7 @@ pub enum PropertyError {
 
 /// A VCARD/ICAL property.
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct Property {
     /// Property name.
     pub name: String,


### PR DESCRIPTION
Hi, thanks for your work on iCalendar files!

On a project of mine, I'd like to store a `Vec<Property>` in a struct that can be serialized/deserialized by `serde`...but this fails because `Property` does not support `serde` itself.

This PR is adding serde support, to `Property` but also to every struct where (I think) it makes sense.

In case you accept it, I'd be glad you released a 0.8.0 with this change, it would help my downstream project :D )