### PR TITLE
Set the license to Apache 2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -201,3 +201,4 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+


### PR DESCRIPTION
When I have first changed the the License, for an unknown reason I have
specified inside the commit message that I have setup an MIT license
while I was pushing the Apache 2 version. This is a human error on my
side.

This commit have for only goal to replace the old commit message in
github in order to avoid confusion.

Fix #38 