### PR TITLE
Add access functions for properties

### DIFF
--- a/src/parser/ical/component.rs
+++ b/src/parser/ical/component.rs
@@ -42,6 +42,14 @@ impl Component for IcalCalendar {
         self.properties.push(property);
     }
 
+    fn get_property<'c>(&'c self, name: &str) -> Option<&'c Property> {
+        self.properties.iter().find(|p| p.name == name)
+    }
+
+    fn get_property_mut<'c>(&'c mut self, name: &str) -> Option<&'c mut Property> {
+        self.properties.iter_mut().find(|p| p.name == name)
+    }
+
     fn add_sub_component<B: BufRead>(
         &mut self,
         value: &str,
@@ -104,6 +112,14 @@ impl Component for IcalAlarm {
         self.properties.push(property);
     }
 
+    fn get_property<'c>(&'c self, name: &str) -> Option<&'c Property> {
+        self.properties.iter().find(|p| p.name == name)
+    }
+
+    fn get_property_mut<'c>(&'c mut self, name: &str) -> Option<&'c mut Property> {
+        self.properties.iter_mut().find(|p| p.name == name)
+    }
+
     fn add_sub_component<B: BufRead>(
         &mut self,
         _: &str,
@@ -132,6 +148,14 @@ impl IcalEvent {
 impl Component for IcalEvent {
     fn add_property(&mut self, property: Property) {
         self.properties.push(property);
+    }
+
+    fn get_property<'c>(&'c self, name: &str) -> Option<&'c Property> {
+        self.properties.iter().find(|p| p.name == name)
+    }
+
+    fn get_property_mut<'c>(&'c mut self, name: &str) -> Option<&'c mut Property> {
+        self.properties.iter_mut().find(|p| p.name == name)
     }
 
     fn add_sub_component<B: BufRead>(
@@ -171,6 +195,14 @@ impl Component for IcalJournal {
         self.properties.push(property);
     }
 
+    fn get_property<'c>(&'c self, name: &str) -> Option<&'c Property> {
+        self.properties.iter().find(|p| p.name == name)
+    }
+
+    fn get_property_mut<'c>(&'c mut self, name: &str) -> Option<&'c mut Property> {
+        self.properties.iter_mut().find(|p| p.name == name)
+    }
+
     fn add_sub_component<B: BufRead>(
         &mut self,
         _: &str,
@@ -199,6 +231,14 @@ impl IcalTodo {
 impl Component for IcalTodo {
     fn add_property(&mut self, property: Property) {
         self.properties.push(property);
+    }
+
+    fn get_property<'c>(&'c self, name: &str) -> Option<&'c Property> {
+        self.properties.iter().find(|p| p.name == name)
+    }
+
+    fn get_property_mut<'c>(&'c mut self, name: &str) -> Option<&'c mut Property> {
+        self.properties.iter_mut().find(|p| p.name == name)
     }
 
     fn add_sub_component<B: BufRead>(
@@ -238,6 +278,14 @@ impl IcalTimeZone {
 impl Component for IcalTimeZone {
     fn add_property(&mut self, property: Property) {
         self.properties.push(property);
+    }
+
+    fn get_property<'c>(&'c self, name: &str) -> Option<&'c Property> {
+        self.properties.iter().find(|p| p.name == name)
+    }
+
+    fn get_property_mut<'c>(&'c mut self, name: &str) -> Option<&'c mut Property> {
+        self.properties.iter_mut().find(|p| p.name == name)
     }
 
     fn add_sub_component<B: BufRead>(
@@ -299,6 +347,14 @@ impl Component for IcalTimeZoneTransition {
         self.properties.push(property);
     }
 
+    fn get_property<'c>(&'c self, name: &str) -> Option<&'c Property> {
+        self.properties.iter().find(|p| p.name == name)
+    }
+
+    fn get_property_mut<'c>(&'c mut self, name: &str) -> Option<&'c mut Property> {
+        self.properties.iter_mut().find(|p| p.name == name)
+    }
+
     fn add_sub_component<B: BufRead>(
         &mut self,
         _: &str,
@@ -325,6 +381,14 @@ impl IcalFreeBusy {
 impl Component for IcalFreeBusy {
     fn add_property(&mut self, property: Property) {
         self.properties.push(property);
+    }
+
+    fn get_property<'c>(&'c self, name: &str) -> Option<&'c Property> {
+        self.properties.iter().find(|p| p.name == name)
+    }
+
+    fn get_property_mut<'c>(&'c mut self, name: &str) -> Option<&'c mut Property> {
+        self.properties.iter_mut().find(|p| p.name == name)
     }
 
     fn add_sub_component<B: BufRead>(

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -43,6 +43,10 @@ pub trait Component {
     /// Add the givent property.
     fn add_property(&mut self, property: Property);
 
+    /// Find a given property.
+    fn get_property<'c>(&'c self, name: &str) -> Option<&'c Property>;
+    fn get_property_mut<'c>(&'c mut self, name: &str) -> Option<&'c mut Property>;
+
     /// Parse the content from `line_parser` and fill the component with.
     fn parse<B: BufRead>(
         &mut self,

--- a/src/parser/vcard/component.rs
+++ b/src/parser/vcard/component.rs
@@ -29,6 +29,14 @@ impl Component for VcardContact {
         self.properties.push(property);
     }
 
+    fn get_property<'c>(&'c self, name: &str) -> Option<&'c Property> {
+        self.properties.iter().find(|p| p.name == name)
+    }
+
+    fn get_property_mut<'c>(&'c mut self, name: &str) -> Option<&'c mut Property> {
+        self.properties.iter_mut().find(|p| p.name == name)
+    }
+
     fn add_sub_component<B: BufRead>(
         &mut self,
         _: &str,


### PR DESCRIPTION
Currently, looking for a `Property` inside of a ical component is rather tedious. I added simple access functions to `trait Component` to make access easier and implemented them for the `Ical*` types.