### PR TITLE
replaced split_line with a multibyte aware version

### DIFF
--- a/src/generator/ical.rs
+++ b/src/generator/ical.rs
@@ -21,8 +21,9 @@ fn get_value(value: &Option<String>) -> String {
 pub(crate) fn split_line<T: Into<String>>(str: T) -> String {
     let str = str.into();
     let mut chars = str.chars();
+    let mut first = true;
     let sub_string = (0..)
-        .map(|_| chars.by_ref().take(75).collect::<String>())
+        .map(|_| chars.by_ref().take(if first { first = false; 75 } else { 74 }).collect::<String>())
         .take_while(|s| !s.is_empty())
         .collect::<Vec<_>>();
     sub_string.join("\r\n ")

--- a/src/generator/ical.rs
+++ b/src/generator/ical.rs
@@ -87,6 +87,14 @@ mod should {
     }
 
     #[test]
+    fn split_long_line_multibyte() {
+        // the following text includes multibyte characters (UTF-8) at strategic places to ensure
+        // split_line would panic if not multibyte aware
+        let text = "DESCRIPTION:ABCDEFGHIJ\\n\\nKLMNOPQRSTUVWXYZ123456789üABCDEFGHIJKLMNOPQRS\\n\\nTUVWXYZ123456ä7890ABCDEFGHIJKLM\\n\\nNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNOPQRSTUVWXöYZ1234567890ABCDEFGHIJKLMNOPQRSTUVWX\\n\\nYZ1234567890abcdefghiÜjklm\\nnopqrstuvwx";
+        assert_eq!(text, split_line(text.replace("\r\n ", "")));
+    }
+
+    #[test]
     fn protect_chars_in_params() {
         assert_eq!(
             protect_params(&String::from("\"value: in quotes;\"")),

--- a/src/generator/ical.rs
+++ b/src/generator/ical.rs
@@ -91,8 +91,8 @@ mod should {
         // the following text includes multibyte characters (UTF-8) at strategic places to ensure
         // split_line would panic if not multibyte aware
         let text = "DESCRIPTION:ABCDEFGHIJ\\n\\nKLMNOPQRSTUVWXYZ123456789üABCDEFGHIJKLMNOPQRS\\n\\n\r\n \
-                     TUVWXYZ123456ä7890ABCDEFGHIJKLM\\n\\nNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNO\r\n \
-                     PQRSTUVWXöYZ1234567890ABCDEFGHIJKLMNOPQRSTUVWX\\n\\nYZ1234567890abcdefghiÜjkl\r\n \
+                     TUVWXYZ123456ä7890ABCDEFGHIJKLM\\n\\nNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNOP\r\n \
+                     QRSTUVWXöYZ1234567890ABCDEFGHIJKLMNOPQRSTUVWX\\n\\nYZ1234567890abcdefghiÜjkl\r\n \
                      m\\nnopqrstuvwx";
         assert_eq!(text, split_line(text.replace("\r\n ", "")));
     }

--- a/src/generator/ical.rs
+++ b/src/generator/ical.rs
@@ -19,13 +19,13 @@ fn get_value(value: &Option<String>) -> String {
 }
 
 pub(crate) fn split_line<T: Into<String>>(str: T) -> String {
-    let mut str = str.into();
-    let mut x = 75;
-    while x < str.len() {
-        str.insert_str(x, "\r\n ");
-        x += 77;
-    }
-    str
+    let str = str.into();
+    let mut chars = str.chars();
+    let sub_string = (0..)
+        .map(|_| chars.by_ref().take(75).collect::<String>())
+        .take_while(|s| !s.is_empty())
+        .collect::<Vec<_>>();
+    sub_string.join("\r\n ")
 }
 
 //

--- a/src/generator/ical.rs
+++ b/src/generator/ical.rs
@@ -90,7 +90,10 @@ mod should {
     fn split_long_line_multibyte() {
         // the following text includes multibyte characters (UTF-8) at strategic places to ensure
         // split_line would panic if not multibyte aware
-        let text = "DESCRIPTION:ABCDEFGHIJ\\n\\nKLMNOPQRSTUVWXYZ123456789üABCDEFGHIJKLMNOPQRS\\n\\nTUVWXYZ123456ä7890ABCDEFGHIJKLM\\n\\nNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNOPQRSTUVWXöYZ1234567890ABCDEFGHIJKLMNOPQRSTUVWX\\n\\nYZ1234567890abcdefghiÜjklm\\nnopqrstuvwx";
+        let text = "DESCRIPTION:ABCDEFGHIJ\\n\\nKLMNOPQRSTUVWXYZ123456789üABCDEFGHIJKLMNOPQRS\\n\\n\r\n \
+                     TUVWXYZ123456ä7890ABCDEFGHIJKLM\\n\\nNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNO\r\n \
+                     PQRSTUVWXöYZ1234567890ABCDEFGHIJKLMNOPQRSTUVWX\\n\\nYZ1234567890abcdefghiÜjkl\r\n \
+                     m\\nnopqrstuvwx";
         assert_eq!(text, split_line(text.replace("\r\n ", "")));
     }
 


### PR DESCRIPTION
split_line was working fine as long as the input was just plain US-ASCII. When using multibyte characters and they happened to be at the end of the line to spit the function did panic.

The new code returns correctly split lines even if they contain multibyte characters.